### PR TITLE
Bug/fix enummeta comparisons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,11 @@ Cache keys are determined by hash key, range key, and a cache prefix
 CHANGELOG
 ---------
 
+0.3.1
+^^^^^
+
+Fixed bug whereby EnumMeta and subclasses were not comparing properly (re: at all) in Python 3.
+
 0.3.0
 ^^^^^
 

--- a/duo.py
+++ b/duo.py
@@ -31,6 +31,7 @@ Got all that? Read on.
 """
 from __future__ import unicode_literals
 from six import with_metaclass, string_types, text_type, iteritems
+from functools import total_ordering
 import warnings
 import collections
 import datetime
@@ -50,6 +51,7 @@ from boto.dynamodb.exceptions import DynamoDBKeyNotFoundError
 # light on what they are and how they work.
 
 
+@total_ordering
 class EnumMeta(type):
     """Simple metaclass for enumerated types.
 
@@ -140,11 +142,17 @@ class EnumMeta(type):
     def __bool__(cls):
         return bool(int(cls))
 
-    def __cmp__(self, other):
+    def __lt__(self, other):
         if isinstance(other, string_types):
-            return cmp(str(self), other)
+            return str(self) < other
         else:
-            return cmp(int(self), other)
+            return int(self) < int(other)
+
+    def __eq__(self, other):
+        if isinstance(other, string_types):
+            return str(self) == other
+        else:
+            return int(self) == int(other)
 
     def __str__(cls):
         try:

--- a/duo.py
+++ b/duo.py
@@ -148,6 +148,12 @@ class EnumMeta(type):
         else:
             return int(self) < int(other)
 
+    def __gt__(self, other):
+        if isinstance(other, string_types):
+            return str(self) > other
+        else:
+            return int(self) > int(other)
+
     def __eq__(self, other):
         if isinstance(other, string_types):
             return str(self) == other

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SETUP = dict(
     },
     zip_safe = False,
 
-    version = "0.3.0",
+    version = "0.3.1",
     description = "A powerful, dynamic, pythonic interface to AWS DynamoDB.",
     long_description = open(README).read(),
     author = "David Eyk",

--- a/test_duo.py
+++ b/test_duo.py
@@ -331,3 +331,27 @@ class DuoTests(DynamoDBTests):
         self.assertIsInstance(item['place'], int)
         self.assertEqual(item['place'], 1)
         self.assertIs(item.place, Bar)
+
+    def test_enum_classes_should_compare(self):
+        class Placeholder(with_metaclass(self.duo.EnumMeta, object)): pass
+
+        class Foo(Placeholder): pass
+
+        class Bar(Placeholder): pass
+
+        class Baz(Placeholder): pass
+
+        self.assertEqual(Foo, 0)
+        self.assertEqual(Foo, 'Foo')
+        self.assertEqual(Foo, Foo)
+        self.assertLess(Foo, Bar)
+        self.assertEqual(Bar, 1)
+        self.assertEqual(Bar, 'Bar')
+        self.assertEqual(Bar, Bar)
+        self.assertGreater(Bar, Foo)
+        self.assertLess(Bar, Baz)
+        self.assertEqual(Baz, 2)
+        self.assertEqual(Baz, 'Baz')
+        self.assertEqual(Baz, Baz)
+        self.assertGreater(Baz, Bar)
+        self.assertLess(Baz, 3)


### PR DESCRIPTION
`EnumMeta` comparisons were failing in Python 3 because they relied on `__cmp__`, which is no longer present (and neither is the builtin `cmp()`.

This adds `__lt__`, `__eq__`, and the `functools.total_ordering` decorator to the EnumMeta class for Python 3 purposes.

`cmp` is left in for python 2.
```shell
GLOB sdist-make: /Users/rrubin/projects/duo/setup.py
py27 inst-nodeps: /Users/rrubin/projects/duo/.tox/dist/duo-0.3.1.zip
py27 installed: boto==2.43.0,coverage==4.2,duo==0.3.1,funcsigs==1.0.2,mock==2.0.0,nose==1.3.7,pbr==1.10.0,six==1.10.0
py27 runtests: PYTHONHASHSEED='1470742131'
py27 runtests: commands[0] | nosetests --with-coverage --cover-package=duo
............
Name     Stmts   Miss  Cover
----------------------------
duo.py     338    104    69%
----------------------------------------------------------------------
Ran 12 tests in 0.141s

OK
py35 inst-nodeps: /Users/rrubin/projects/duo/.tox/dist/duo-0.3.1.zip
py35 installed: boto==2.43.0,coverage==4.2,duo==0.3.1,mock==2.0.0,nose==1.3.7,pbr==1.10.0,six==1.10.0
py35 runtests: PYTHONHASHSEED='1470742131'
py35 runtests: commands[0] | nosetests --with-coverage --cover-package=duo
............
Name     Stmts   Miss  Cover
----------------------------
duo.py     338    102    70%
----------------------------------------------------------------------
Ran 12 tests in 0.175s

OK
______________________________________________________________________ summary _______________________________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  congratulations :)
```